### PR TITLE
修复课程卡星级评价模糊问题

### DIFF
--- a/src/components/StarRating.vue
+++ b/src/components/StarRating.vue
@@ -87,6 +87,7 @@ const getStarFillStyle = (starNumber: number): { width: string } => {
   );
   background-color: #e0e0e0;
   border: 1px solid #d0d0d0;
+  shape-rendering: crispEdges;
 }
 
 /* 实心星星填充 */
@@ -109,6 +110,7 @@ const getStarFillStyle = (starNumber: number): { width: string } => {
     39% 35%
   );
   background: linear-gradient(135deg, #ffc107 0%, #ff8f00 100%);
+  shape-rendering: crispEdges;
   transition: width 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- revert StarRating to CSS clip-path implementation
- add crispEdges rendering for both empty and filled stars

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870eb625ff48320be0798362a0fe0cb